### PR TITLE
Improve errors

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2010-2017 Google, Inc. http://angularjs.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # s3file
 
+[![Go Report Card](https://goreportcard.com/badge/github.com/dwtechnologies/s3file)](https://goreportcard.com/report/github.com/dwtechnologies/s3file)
+
 The s3file package is a heler package to the official aws-go-sdk.
 It will make it easier to
 

--- a/s3_put.go
+++ b/s3_put.go
@@ -116,14 +116,14 @@ func PutFile(c *PutFileRequest) error {
 
 		fileSize = fileSize - chunkSize
 		chunkSize = getChunkSizes(fileSize, chunkMaxSize)
-		partCounter++
-		// Read the next chunk of the file
-		_, err = f.Read(chunk)
-
 		// If chunkSize is 0, indicate that we have reached EOF
 		if chunkSize == 0 {
 			err = io.EOF
 		}
+
+		partCounter++
+		// Read the next chunk of the file
+		_, err = f.Read(chunk)
 	}
 
 	// Add all the completed parts a slice of completedParts

--- a/structs.go
+++ b/structs.go
@@ -1,10 +1,14 @@
 package s3file
 
-import "os"
+import (
+	"os"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+)
 
 var awsRegion = os.Getenv("AWS_REGION")
 
-// PutFileRequest is used by the PutFile function. You specify the necessary paramters for the file upload.
+// PutFileRequest is used by the PutFile function. You specify the necessary parameters for the file upload.
 type PutFileRequest struct {
 	S3Bucket    string // Bucket to upload file to
 	S3Prefix    string // Prefix to use for upload
@@ -14,9 +18,14 @@ type PutFileRequest struct {
 	ContentType string // Set the content type, will default to text/plain; charset=utf-8
 }
 
-// FileRequest is used by the FileExists, GetFile and RemoveFile functions. You specify the necessary paramters for the file upload.
+// FileRequest is used by the FileExists, GetFile and RemoveFile functions. You specify the necessary parameters for the file upload.
 type FileRequest struct {
 	S3Bucket   string // Bucket to upload file to
 	S3Prefix   string // Prefix to use for upload
 	S3Filename string // Filename to use on S3
+}
+
+type completedPart struct {
+	part *s3.CompletedPart
+	err  error
 }


### PR DESCRIPTION
Moved errors to struct and channel to be able to return parts errors.
Added license.
Fixed minor spelling faults.
Removed all fmt.Println to stdout.